### PR TITLE
Swagger decorators moved to `@common/decorators/swagger`

### DIFF
--- a/libs/common/src/decorators/swagger/auth.decorator.ts
+++ b/libs/common/src/decorators/swagger/auth.decorator.ts
@@ -8,9 +8,9 @@ import {
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { UserResponse } from '@user/responses';
-import { TokensResponse } from '../../../../../src/auth/responses';
+import { TokensResponse } from '@auth/responses';
 import { CreateUserDTO as RegisterDTO } from '@user/dto';
-import { LoginDTO } from '../../../../../src/auth/dto';
+import { LoginDTO } from '@auth/dto';
 
 export function AuthRegistrationSwaggerDecorator() {
   return applyDecorators(

--- a/libs/common/src/decorators/swagger/auth.decorator.ts
+++ b/libs/common/src/decorators/swagger/auth.decorator.ts
@@ -1,0 +1,40 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiBody,
+  ApiCookieAuth,
+  ApiOkResponse,
+  ApiOperation,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { UserResponse } from '@user/responses';
+import { TokensResponse } from '../../../../../src/auth/responses';
+import { CreateUserDTO as RegisterDTO } from '@user/dto';
+import { LoginDTO } from '../../../../../src/auth/dto';
+
+export function AuthRegistrationSwaggerDecorator() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Registration of new user' }),
+    ApiBody({ type: RegisterDTO }),
+    ApiOkResponse({ type: UserResponse }),
+    ApiBadRequestResponse({ description: 'User with this credentials already exists' }),
+  );
+}
+
+export function AuthLoginSwaggerDecorator() {
+  return applyDecorators(
+    ApiOperation({ summary: 'User login to the system' }),
+    ApiBody({ type: LoginDTO }),
+    ApiOkResponse({ type: TokensResponse }),
+    ApiUnauthorizedResponse({ description: 'Incorrect email or password' }),
+  );
+}
+
+export function AuthRefreshTokensSwaggerDecorator() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Generates new pair of tokens (access and refresh)' }),
+    ApiOkResponse({ type: TokensResponse }),
+    ApiUnauthorizedResponse({ description: 'Something wrong with token' }),
+    ApiCookieAuth(),
+  );
+}

--- a/libs/common/src/decorators/swagger/index.ts
+++ b/libs/common/src/decorators/swagger/index.ts
@@ -1,0 +1,1 @@
+export * from './auth.decorator';

--- a/libs/common/src/decorators/swagger/index.ts
+++ b/libs/common/src/decorators/swagger/index.ts
@@ -1,1 +1,2 @@
 export * from './auth.decorator';
+export * from './user.decorator';

--- a/libs/common/src/decorators/swagger/index.ts
+++ b/libs/common/src/decorators/swagger/index.ts
@@ -1,2 +1,3 @@
 export * from './auth.decorator';
 export * from './user.decorator';
+export * from './tutor.decorator';

--- a/libs/common/src/decorators/swagger/index.ts
+++ b/libs/common/src/decorators/swagger/index.ts
@@ -1,3 +1,4 @@
 export * from './auth.decorator';
 export * from './user.decorator';
 export * from './tutor.decorator';
+export * from './student.decorator';

--- a/libs/common/src/decorators/swagger/student.decorator.ts
+++ b/libs/common/src/decorators/swagger/student.decorator.ts
@@ -1,0 +1,44 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiBody,
+  ApiCreatedResponse,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+} from '@nestjs/swagger';
+import { StudentProfileResponse } from '@student/responses';
+import { CreateStudentProfileDTO, UpdateStudentProfileDTO } from '@student/dto';
+
+export function StudentFindOneSwaggerDecorator() {
+  return applyDecorators(
+    ApiOperation({ summary: "Retrieves student's profile with given userID" }),
+    ApiOkResponse({ type: StudentProfileResponse }),
+    ApiNotFoundResponse({ description: 'Profile not found' }),
+  );
+}
+
+export function StudentCreateProfileSwaggerDecorator() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Creates profile for student with given userID' }),
+    ApiBody({ type: CreateStudentProfileDTO }),
+    ApiCreatedResponse({ type: StudentProfileResponse }),
+    ApiBadRequestResponse({ description: 'This student already has a profile' }),
+    ApiForbiddenResponse({ description: 'User is not student' }),
+    ApiNotFoundResponse({ description: 'User not found' }),
+    ApiBearerAuth('JWT-auth'),
+  );
+}
+
+export function StudentUpdateProfileSwaggerDecorator() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Updates profile of student with given userID' }),
+    ApiBody({ type: UpdateStudentProfileDTO }),
+    ApiOkResponse({ type: StudentProfileResponse }),
+    ApiBadRequestResponse({ description: 'This user does not have a profile' }),
+    ApiNotFoundResponse({ description: 'User not found' }),
+    ApiBearerAuth('JWT-auth'),
+  );
+}

--- a/libs/common/src/decorators/swagger/tutor.decorator.ts
+++ b/libs/common/src/decorators/swagger/tutor.decorator.ts
@@ -1,0 +1,87 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiBody,
+  ApiConsumes,
+  ApiCreatedResponse,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+} from '@nestjs/swagger';
+import { AchievementResponse, FullTutorProfileResponse, TutorProfileResponse } from '@tutor/responses';
+import { CreateAchievementDTO, CreateTutorProfileDTO, UpdateAchievementDTO, UpdateTutorProfileDTO } from '@tutor/dto';
+import { DeleteResponse } from '@common/responses';
+
+export function TutorFindOneSwaggerDecorator() {
+  return applyDecorators(
+    ApiOperation({ summary: "Retrieves tutor's profile with given userID" }),
+    ApiOkResponse({ type: FullTutorProfileResponse }),
+    ApiNotFoundResponse({ description: 'User not found' }),
+  );
+}
+
+export function TutorCreateProfileSwaggerDecorator() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Creates profile for tutor with given userID' }),
+    ApiBody({ type: CreateTutorProfileDTO }),
+    ApiCreatedResponse({ type: TutorProfileResponse }),
+    ApiBadRequestResponse({ description: 'This tutor already has a profile' }),
+    ApiForbiddenResponse({ description: 'User is not tutor' }),
+    ApiNotFoundResponse({ description: 'User not found' }),
+    ApiBearerAuth('JWT-auth'),
+  );
+}
+
+export function TutorUpdateProfileSwaggerDecorator() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Updates profile of tutor with given userID' }),
+    ApiBody({ type: UpdateTutorProfileDTO }),
+    ApiOkResponse({ type: TutorProfileResponse }),
+    ApiBadRequestResponse({ description: 'This user does not have a profile' }),
+    ApiNotFoundResponse({ description: 'User not found' }),
+    ApiBearerAuth('JWT-auth'),
+  );
+}
+
+export function TutorAddAchievementSwaggerDecorator() {
+  return applyDecorators(
+    ApiConsumes('multipart/form-data'),
+    ApiBody({ type: CreateAchievementDTO }),
+    ApiOperation({ summary: 'Creates achievement for tutor with given userId' }),
+    ApiCreatedResponse({ type: AchievementResponse }),
+    ApiNotFoundResponse({ description: "Tutor's profile not found" }),
+    ApiBearerAuth('JWT-auth'),
+  );
+}
+
+export function TutorUpdateAchievementSwaggerDecorator() {
+  return applyDecorators(
+    ApiConsumes('multipart/form-data'),
+    ApiOperation({ summary: 'Updates achievement for tutor with given userId' }),
+    ApiBody({ type: UpdateAchievementDTO }),
+    ApiOkResponse({ type: AchievementResponse }),
+    ApiForbiddenResponse({ description: 'Confirmed achievement can not be updated' }),
+    ApiNotFoundResponse({ description: "Tutor's profile not found or This tutor does not have such an achievement" }),
+    ApiBearerAuth('JWT-auth'),
+  );
+}
+
+export function TutorDeleteAchievementSwaggerDecorator() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Deletes achievement' }),
+    ApiOkResponse({ type: DeleteResponse }),
+    ApiNotFoundResponse({ description: "Tutor's profile not found or This tutor does not have such an achievement" }),
+    ApiBearerAuth('JWT-auth'),
+  );
+}
+
+export function TutorConfirmAchievementSwaggerDecorator() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Sets isConfirmed field of achievement to TRUE' }),
+    ApiOkResponse({ type: AchievementResponse }),
+    ApiNotFoundResponse({ description: "Tutor's profile not found or This tutor does not have such an achievement" }),
+    ApiBearerAuth('JWT-auth'),
+  );
+}

--- a/libs/common/src/decorators/swagger/user.decorator.ts
+++ b/libs/common/src/decorators/swagger/user.decorator.ts
@@ -1,0 +1,35 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBearerAuth, ApiBody, ApiNotFoundResponse, ApiOkResponse, ApiOperation } from '@nestjs/swagger';
+import { UserResponse } from '@user/responses';
+import { UpdateUserDTO } from '@user/dto';
+import { DeleteResponse } from '@common/responses';
+
+export function UserFindAllSwaggerDecorator() {
+  return applyDecorators(ApiOperation({ summary: 'Retrieves all users' }), ApiOkResponse({ type: [UserResponse] }));
+}
+
+export function UserFindOneSwaggerDecorator() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Retrieves user with given ID' }),
+    ApiOkResponse({ type: UserResponse }),
+    ApiNotFoundResponse({ description: 'User not found' }),
+  );
+}
+
+export function UserUpdateSwaggerDecorator() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Updates user with given ID' }),
+    ApiBody({ type: UpdateUserDTO }),
+    ApiOkResponse({ type: UserResponse }),
+    ApiNotFoundResponse({ description: 'User not found' }),
+    ApiBearerAuth('JWT-auth'),
+  );
+}
+
+export function UserDeleteSwaggerDecorator() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Deletes user with given ID' }),
+    ApiOkResponse({ type: DeleteResponse }),
+    ApiBearerAuth('JWT-auth'),
+  );
+}

--- a/libs/common/src/responses/delete.response.ts
+++ b/libs/common/src/responses/delete.response.ts
@@ -1,0 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DeleteResponse {
+  @ApiProperty({ example: '07abea78-7035-42c1-928d-1ef4f981267e' })
+  id: string;
+}

--- a/libs/common/src/responses/index.ts
+++ b/libs/common/src/responses/index.ts
@@ -1,0 +1,1 @@
+export * from './delete.response';

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -6,17 +6,13 @@ import { Tokens } from './interfaces';
 import { Response } from 'express';
 import { ConfigService } from '@nestjs/config';
 import { Cookie, Public, UserAgent } from '@common/decorators';
-import {
-  ApiBadRequestResponse,
-  ApiCookieAuth,
-  ApiOkResponse,
-  ApiOperation,
-  ApiTags,
-  ApiUnauthorizedResponse,
-} from '@nestjs/swagger';
-import { UserResponse } from '@user/responses';
-import { TokensResponse } from './responses';
+import { ApiTags } from '@nestjs/swagger';
 import { REFRESH_TOKEN_COOKIE_NAME } from '@common/constants';
+import {
+  AuthLoginSwaggerDecorator,
+  AuthRefreshTokensSwaggerDecorator,
+  AuthRegistrationSwaggerDecorator,
+} from '@common/decorators/swagger';
 
 @Public()
 @Controller('auth')
@@ -28,28 +24,21 @@ export class AuthController {
   ) {}
 
   @Post('register')
-  @ApiOperation({ summary: 'Registration of new user' })
-  @ApiOkResponse({ type: UserResponse })
-  @ApiBadRequestResponse({ description: 'User with this credentials already exists' })
+  @AuthRegistrationSwaggerDecorator()
   register(@Body() dto: RegisterDTO) {
     console.log(dto);
     return this.authService.register(dto);
   }
 
   @Post('login')
-  @ApiOperation({ summary: 'User login to the system' })
-  @ApiOkResponse({ type: TokensResponse })
-  @ApiUnauthorizedResponse({ description: 'Incorrect email or password' })
+  @AuthLoginSwaggerDecorator()
   async login(@Body() dto: LoginDTO, @Res() response: Response, @UserAgent() userAgent: string) {
     const tokens = await this.authService.login(dto, userAgent);
     this.setRefreshTokenToCookies(tokens, response);
   }
 
   @Get('refresh-tokens')
-  @ApiOperation({ summary: 'Generates new pair of tokens (access and refresh)' })
-  @ApiOkResponse({ type: TokensResponse })
-  @ApiUnauthorizedResponse({ description: 'Something wrong with token' })
-  @ApiCookieAuth()
+  @AuthRefreshTokensSwaggerDecorator()
   async refreshTokens(
     @Cookie(REFRESH_TOKEN_COOKIE_NAME) refreshToken: string,
     @Res() response: Response,

--- a/src/student/student.controller.ts
+++ b/src/student/student.controller.ts
@@ -14,29 +14,23 @@ import {
 import { StudentService } from './student.service';
 import { CreateStudentProfileDTO, UpdateStudentProfileDTO } from './dto';
 import { StudentProfileResponse } from './responses';
-import {
-  ApiBadRequestResponse,
-  ApiBearerAuth,
-  ApiCreatedResponse,
-  ApiForbiddenResponse,
-  ApiNotFoundResponse,
-  ApiOkResponse,
-  ApiOperation,
-  ApiTags,
-} from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 import { Public } from '@common/decorators';
+import {
+  StudentCreateProfileSwaggerDecorator,
+  StudentFindOneSwaggerDecorator,
+  StudentUpdateProfileSwaggerDecorator,
+} from '@common/decorators/swagger/';
 
 @Controller('students')
-@ApiTags('Students')
 @UseInterceptors(ClassSerializerInterceptor)
+@ApiTags('Students')
 export class StudentController {
   constructor(private readonly studentService: StudentService) {}
 
   @Get(':userId/profile')
   @Public()
-  @ApiOperation({ summary: "Retrieves student's profile with given userID" })
-  @ApiOkResponse({ type: StudentProfileResponse })
-  @ApiNotFoundResponse({ description: 'Profile not found' })
+  @StudentFindOneSwaggerDecorator()
   async findOne(@Param('userId', ParseUUIDPipe) userId: string) {
     const profile = await this.studentService.findOneProfile(userId);
     return new StudentProfileResponse(profile);
@@ -44,12 +38,7 @@ export class StudentController {
 
   @Post(':userId/profile')
   @HttpCode(HttpStatus.CREATED)
-  @ApiOperation({ summary: 'Creates profile for student with given userID' })
-  @ApiCreatedResponse({ type: StudentProfileResponse })
-  @ApiBadRequestResponse({ description: 'This student already has a profile' })
-  @ApiForbiddenResponse({ description: 'User is not student' })
-  @ApiNotFoundResponse({ description: 'User not found' })
-  @ApiBearerAuth('JWT-auth')
+  @StudentCreateProfileSwaggerDecorator()
   async createProfile(
     @Param('userId', ParseUUIDPipe) userId: string,
     @Body() createStudentDto: CreateStudentProfileDTO,
@@ -59,11 +48,7 @@ export class StudentController {
   }
 
   @Put(':userId/profile')
-  @ApiOperation({ summary: 'Updates profile of student with given userID' })
-  @ApiOkResponse({ type: StudentProfileResponse })
-  @ApiBadRequestResponse({ description: 'This user does not have a profile' })
-  @ApiNotFoundResponse({ description: 'User not found' })
-  @ApiBearerAuth('JWT-auth')
+  @StudentUpdateProfileSwaggerDecorator()
   async updateProfile(
     @Param('userId', ParseUUIDPipe) userId: string,
     @Body() updateStudentDto: UpdateStudentProfileDTO,

--- a/src/tutor/tutor.controller.ts
+++ b/src/tutor/tutor.controller.ts
@@ -15,18 +15,17 @@ import {
 import { TutorService } from './tutor.service';
 import { CreateAchievementDTO, CreateTutorProfileDTO, UpdateAchievementDTO, UpdateTutorProfileDTO } from './dto';
 import { AchievementResponse, FullTutorProfileResponse, TutorProfileResponse } from './responses';
-import {
-  ApiBadRequestResponse,
-  ApiBearerAuth,
-  ApiConsumes,
-  ApiCreatedResponse,
-  ApiForbiddenResponse,
-  ApiNotFoundResponse,
-  ApiOkResponse,
-  ApiOperation,
-  ApiTags,
-} from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 import { Public } from '@common/decorators';
+import {
+  TutorAddAchievementSwaggerDecorator,
+  TutorConfirmAchievementSwaggerDecorator,
+  TutorCreateProfileSwaggerDecorator,
+  TutorDeleteAchievementSwaggerDecorator,
+  TutorFindOneSwaggerDecorator,
+  TutorUpdateAchievementSwaggerDecorator,
+  TutorUpdateProfileSwaggerDecorator,
+} from '@common/decorators/swagger';
 
 @Controller('tutors')
 @ApiTags('Tutors')
@@ -36,9 +35,7 @@ export class TutorController {
 
   @Get(':userId')
   @Public()
-  @ApiOperation({ summary: "Retrieves tutor's profile with given userID" })
-  @ApiOkResponse({ type: FullTutorProfileResponse })
-  @ApiNotFoundResponse({ description: 'User not found' })
+  @TutorFindOneSwaggerDecorator()
   async findOne(@Param('userId', ParseUUIDPipe) userId: string) {
     const profile = await this.tutorService.findOneProfile(userId);
     return new FullTutorProfileResponse(profile);
@@ -46,23 +43,14 @@ export class TutorController {
 
   @Post(':userId/profile')
   @HttpCode(HttpStatus.CREATED)
-  @ApiOperation({ summary: 'Creates profile for tutor with given userID' })
-  @ApiCreatedResponse({ type: TutorProfileResponse })
-  @ApiBadRequestResponse({ description: 'This tutor already has a profile' })
-  @ApiForbiddenResponse({ description: 'User is not tutor' })
-  @ApiNotFoundResponse({ description: 'User not found' })
-  @ApiBearerAuth('JWT-auth')
+  @TutorCreateProfileSwaggerDecorator()
   async createProfile(@Param('userId', ParseUUIDPipe) userId: string, @Body() dto: CreateTutorProfileDTO) {
     const profile = await this.tutorService.createProfile(userId, dto);
     return new TutorProfileResponse(profile);
   }
 
   @Put(':userId/profile')
-  @ApiOperation({ summary: 'Updates profile of tutor with given userID' })
-  @ApiOkResponse({ type: TutorProfileResponse })
-  @ApiBadRequestResponse({ description: 'This user does not have a profile' })
-  @ApiNotFoundResponse({ description: 'User not found' })
-  @ApiBearerAuth('JWT-auth')
+  @TutorUpdateProfileSwaggerDecorator()
   async updateProfile(@Param('userId', ParseUUIDPipe) userId: string, @Body() dto: UpdateTutorProfileDTO) {
     const updatedProfile = await this.tutorService.updateProfile(userId, dto);
     return new TutorProfileResponse(updatedProfile);
@@ -70,23 +58,14 @@ export class TutorController {
 
   @Post(':userId/achievements')
   @HttpCode(HttpStatus.CREATED)
-  @ApiConsumes('multipart/form-data')
-  @ApiOperation({ summary: 'Creates achievement for tutor with given userId' })
-  @ApiCreatedResponse({ type: AchievementResponse })
-  @ApiNotFoundResponse({ description: "Tutor's profile not found" })
-  @ApiBearerAuth('JWT-auth')
+  @TutorAddAchievementSwaggerDecorator()
   async addAchievement(@Param('userId', ParseUUIDPipe) userId: string, @Body() dto: CreateAchievementDTO) {
     const achievement = await this.tutorService.addAchievement(userId, dto);
     return new AchievementResponse(achievement);
   }
 
   @Put(':userId/achievements/:achievementId')
-  @ApiConsumes('multipart/form-data')
-  @ApiOperation({ summary: 'Updates achievement for tutor with given userId' })
-  @ApiOkResponse({ type: AchievementResponse })
-  @ApiForbiddenResponse({ description: 'Confirmed achievement can not be updated' })
-  @ApiNotFoundResponse({ description: "Tutor's profile not found or This tutor does not have such an achievement" })
-  @ApiBearerAuth('JWT-auth')
+  @TutorUpdateAchievementSwaggerDecorator()
   async updateAchievement(
     @Param('achievementId', ParseUUIDPipe) achievementId: string,
     @Param('userId', ParseUUIDPipe) userId: string,
@@ -97,10 +76,7 @@ export class TutorController {
   }
 
   @Delete(':userId/achievements/:achievementId')
-  @ApiOperation({ summary: 'Deletes achievement' })
-  @ApiOkResponse()
-  @ApiNotFoundResponse({ description: "Tutor's profile not found or This tutor does not have such an achievement" })
-  @ApiBearerAuth('JWT-auth')
+  @TutorDeleteAchievementSwaggerDecorator()
   async deleteAchievement(
     @Param('achievementId', ParseUUIDPipe) achievementId: string,
     @Param('userId', ParseUUIDPipe) userId: string,
@@ -109,10 +85,7 @@ export class TutorController {
   }
 
   @Put(':userId/achievements/:achievementId/confirm')
-  @ApiOperation({ summary: 'Sets isConfirmed field of achievement to TRUE' })
-  @ApiOkResponse({ type: AchievementResponse })
-  @ApiNotFoundResponse({ description: "Tutor's profile not found or This tutor does not have such an achievement" })
-  @ApiBearerAuth('JWT-auth')
+  @TutorConfirmAchievementSwaggerDecorator()
   async confirmAchievement(
     @Param('achievementId', ParseUUIDPipe) achievementId: string,
     @Param('userId', ParseUUIDPipe) userId: string,

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -11,10 +11,16 @@ import {
 } from '@nestjs/common';
 import { UserService } from '@user/user.service';
 import { UpdateUserDTO } from '@user/dto';
-import { DeleteResponse, UserResponse } from '@user/responses';
+import { UserResponse } from '@user/responses';
 import { User } from '@prisma/client';
-import { ApiBearerAuth, ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 import { Public } from '@common/decorators';
+import {
+  UserDeleteSwaggerDecorator,
+  UserFindAllSwaggerDecorator,
+  UserFindOneSwaggerDecorator,
+  UserUpdateSwaggerDecorator,
+} from '@common/decorators/swagger';
 
 @Controller('users')
 @ApiTags('Users')
@@ -24,8 +30,7 @@ export class UserController {
 
   @Get()
   @Public()
-  @ApiOperation({ summary: 'Retrieves all users' })
-  @ApiOkResponse({ type: [UserResponse] })
+  @UserFindAllSwaggerDecorator()
   async findAll() {
     const users = await this.userService.findAll();
     return users.map((user: User) => new UserResponse(user));
@@ -33,28 +38,21 @@ export class UserController {
 
   @Get(':id')
   @Public()
-  @ApiOperation({ summary: 'Retrieves user with given ID' })
-  @ApiOkResponse({ type: UserResponse })
-  @ApiNotFoundResponse({ description: 'User not found' })
+  @UserFindOneSwaggerDecorator()
   async findOne(@Param('id', ParseUUIDPipe) id: string) {
     const user = await this.userService.findOne(id, true);
     return new UserResponse(user);
   }
 
   @Put(':id')
-  @ApiOperation({ summary: 'Updates user with given ID' })
-  @ApiOkResponse({ type: UserResponse })
-  @ApiNotFoundResponse({ description: 'User not found' })
-  @ApiBearerAuth('JWT-auth')
+  @UserUpdateSwaggerDecorator()
   async update(@Param('id', ParseUUIDPipe) id: string, @Body() dto: UpdateUserDTO) {
     const user = await this.userService.update(id, dto);
     return new UserResponse(user);
   }
 
   @Delete(':id')
-  @ApiOperation({ summary: 'Deletes user with given ID' })
-  @ApiOkResponse({ type: DeleteResponse })
-  @ApiBearerAuth('JWT-auth')
+  @UserDeleteSwaggerDecorator()
   async delete(@Param('id', ParseUUIDPipe) id: string) {
     return this.userService.delete(id);
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,11 +24,29 @@
       "@prisma/*": [
         "src/prisma/*"
       ],
+      "@auth": [
+        "src/auth"
+      ],
+      "@auth/*": [
+        "src/auth/*"
+      ],
       "@user": [
         "src/user"
       ],
       "@user/*": [
         "src/user/*"
+      ],
+      "@tutor": [
+        "src/tutor"
+      ],
+      "@tutor/*": [
+        "src/tutor/*"
+      ],
+      "@student": [
+        "src/student"
+      ],
+      "@student/*": [
+        "src/student/*"
       ],
       "@common": [
         "libs/common/src"


### PR DESCRIPTION
All swagger decorators are moved to `@common/decorators/swagger` ([here](https://github.com/S1riyS/TutorHub-server/tree/master/libs/common/src/decorators/swagger)) in order to reduce visual load of controllers (only one decorator, insted of 4-5)