### PR TITLE
Added roles checking

### DIFF
--- a/libs/common/src/decorators/current-user.decorator.ts
+++ b/libs/common/src/decorators/current-user.decorator.ts
@@ -1,0 +1,7 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { JwtPayload } from '@auth/interfaces';
+
+export const CurrentUser = createParamDecorator((key: keyof JwtPayload, ctx: ExecutionContext): Partial<JwtPayload> => {
+  const request = ctx.switchToHttp().getRequest();
+  return key ? request.user[key] : request.user;
+});

--- a/libs/common/src/decorators/index.ts
+++ b/libs/common/src/decorators/index.ts
@@ -1,3 +1,4 @@
 export * from './cookies.decorator';
 export * from './user-agent.decorator';
 export * from './public.decorator';
+export * from './current-user.decorator';

--- a/libs/common/src/decorators/index.ts
+++ b/libs/common/src/decorators/index.ts
@@ -2,3 +2,4 @@ export * from './cookies.decorator';
 export * from './user-agent.decorator';
 export * from './public.decorator';
 export * from './current-user.decorator';
+export * from './roles.decorator';

--- a/libs/common/src/decorators/roles.decorator.ts
+++ b/libs/common/src/decorators/roles.decorator.ts
@@ -1,0 +1,6 @@
+import { Role } from '@prisma/client';
+import { applyDecorators, SetMetadata, UseGuards } from '@nestjs/common';
+import { RolesGuard } from '@auth/guards/roles.guard';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: Role[]) => applyDecorators(UseGuards(RolesGuard), SetMetadata(ROLES_KEY, roles));

--- a/libs/common/src/decorators/swagger/student.decorator.ts
+++ b/libs/common/src/decorators/swagger/student.decorator.ts
@@ -22,7 +22,7 @@ export function StudentFindOneSwaggerDecorator() {
 
 export function StudentCreateProfileSwaggerDecorator() {
   return applyDecorators(
-    ApiOperation({ summary: 'Creates profile for student with given userID' }),
+    ApiOperation({ summary: 'Creates profile for authorized student' }),
     ApiBody({ type: CreateStudentProfileDTO }),
     ApiCreatedResponse({ type: StudentProfileResponse }),
     ApiBadRequestResponse({ description: 'This student already has a profile' }),
@@ -34,7 +34,7 @@ export function StudentCreateProfileSwaggerDecorator() {
 
 export function StudentUpdateProfileSwaggerDecorator() {
   return applyDecorators(
-    ApiOperation({ summary: 'Updates profile of student with given userID' }),
+    ApiOperation({ summary: 'Updates profile of authorized student' }),
     ApiBody({ type: UpdateStudentProfileDTO }),
     ApiOkResponse({ type: StudentProfileResponse }),
     ApiBadRequestResponse({ description: 'This user does not have a profile' }),

--- a/libs/common/src/decorators/swagger/tutor.decorator.ts
+++ b/libs/common/src/decorators/swagger/tutor.decorator.ts
@@ -40,6 +40,7 @@ export function TutorUpdateProfileSwaggerDecorator() {
     ApiBody({ type: UpdateTutorProfileDTO }),
     ApiOkResponse({ type: TutorProfileResponse }),
     ApiBadRequestResponse({ description: 'This user does not have a profile' }),
+    ApiForbiddenResponse({ description: "Profile can't be updated" }),
     ApiNotFoundResponse({ description: 'User not found' }),
     ApiBearerAuth('JWT-auth'),
   );

--- a/libs/common/src/decorators/swagger/tutor.decorator.ts
+++ b/libs/common/src/decorators/swagger/tutor.decorator.ts
@@ -24,7 +24,7 @@ export function TutorFindOneSwaggerDecorator() {
 
 export function TutorCreateProfileSwaggerDecorator() {
   return applyDecorators(
-    ApiOperation({ summary: 'Creates profile for tutor with given userID' }),
+    ApiOperation({ summary: 'Creates profile for authorized tutor' }),
     ApiBody({ type: CreateTutorProfileDTO }),
     ApiCreatedResponse({ type: TutorProfileResponse }),
     ApiBadRequestResponse({ description: 'This tutor already has a profile' }),
@@ -36,7 +36,7 @@ export function TutorCreateProfileSwaggerDecorator() {
 
 export function TutorUpdateProfileSwaggerDecorator() {
   return applyDecorators(
-    ApiOperation({ summary: 'Updates profile of tutor with given userID' }),
+    ApiOperation({ summary: 'Updates profile of authorized tutor' }),
     ApiBody({ type: UpdateTutorProfileDTO }),
     ApiOkResponse({ type: TutorProfileResponse }),
     ApiBadRequestResponse({ description: 'This user does not have a profile' }),
@@ -50,7 +50,7 @@ export function TutorAddAchievementSwaggerDecorator() {
   return applyDecorators(
     ApiConsumes('multipart/form-data'),
     ApiBody({ type: CreateAchievementDTO }),
-    ApiOperation({ summary: 'Creates achievement for tutor with given userId' }),
+    ApiOperation({ summary: 'Creates new achievement for authorized tutor' }),
     ApiCreatedResponse({ type: AchievementResponse }),
     ApiNotFoundResponse({ description: "Tutor's profile not found" }),
     ApiBearerAuth('JWT-auth'),
@@ -60,7 +60,7 @@ export function TutorAddAchievementSwaggerDecorator() {
 export function TutorUpdateAchievementSwaggerDecorator() {
   return applyDecorators(
     ApiConsumes('multipart/form-data'),
-    ApiOperation({ summary: 'Updates achievement for tutor with given userId' }),
+    ApiOperation({ summary: 'Updates achievement of authorized tutor' }),
     ApiBody({ type: UpdateAchievementDTO }),
     ApiOkResponse({ type: AchievementResponse }),
     ApiForbiddenResponse({ description: 'Confirmed achievement can not be updated' }),
@@ -71,7 +71,7 @@ export function TutorUpdateAchievementSwaggerDecorator() {
 
 export function TutorDeleteAchievementSwaggerDecorator() {
   return applyDecorators(
-    ApiOperation({ summary: 'Deletes achievement' }),
+    ApiOperation({ summary: 'Deletes achievement of authorized tutor' }),
     ApiOkResponse({ type: DeleteResponse }),
     ApiNotFoundResponse({ description: "Tutor's profile not found or This tutor does not have such an achievement" }),
     ApiBearerAuth('JWT-auth'),
@@ -80,7 +80,10 @@ export function TutorDeleteAchievementSwaggerDecorator() {
 
 export function TutorConfirmAchievementSwaggerDecorator() {
   return applyDecorators(
-    ApiOperation({ summary: 'Sets isConfirmed field of achievement to TRUE' }),
+    ApiOperation({
+      summary: 'Confirmation of achievement',
+      description: 'Sets isConfirmed field of achievement to TRUE (ADMIN ONLY)',
+    }),
     ApiOkResponse({ type: AchievementResponse }),
     ApiNotFoundResponse({ description: "Tutor's profile not found or This tutor does not have such an achievement" }),
     ApiBearerAuth('JWT-auth'),

--- a/libs/common/src/decorators/swagger/user.decorator.ts
+++ b/libs/common/src/decorators/swagger/user.decorator.ts
@@ -28,6 +28,7 @@ export function UserUpdateSwaggerDecorator() {
     ApiOperation({ summary: 'Updates user with given ID' }),
     ApiBody({ type: UpdateUserDTO }),
     ApiOkResponse({ type: UserResponse }),
+    ApiForbiddenResponse({ description: "User can't be updated" }),
     ApiNotFoundResponse({ description: 'User not found' }),
     ApiBearerAuth('JWT-auth'),
   );

--- a/libs/common/src/decorators/swagger/user.decorator.ts
+++ b/libs/common/src/decorators/swagger/user.decorator.ts
@@ -1,5 +1,12 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiBearerAuth, ApiBody, ApiNotFoundResponse, ApiOkResponse, ApiOperation } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+} from '@nestjs/swagger';
 import { UserResponse } from '@user/responses';
 import { UpdateUserDTO } from '@user/dto';
 import { DeleteResponse } from '@common/responses';
@@ -30,6 +37,7 @@ export function UserDeleteSwaggerDecorator() {
   return applyDecorators(
     ApiOperation({ summary: 'Deletes user with given ID' }),
     ApiOkResponse({ type: DeleteResponse }),
+    ApiForbiddenResponse({ description: "User can't be deleted" }),
     ApiBearerAuth('JWT-auth'),
   );
 }

--- a/libs/common/src/decorators/swagger/user.decorator.ts
+++ b/libs/common/src/decorators/swagger/user.decorator.ts
@@ -25,7 +25,7 @@ export function UserFindOneSwaggerDecorator() {
 
 export function UserUpdateSwaggerDecorator() {
   return applyDecorators(
-    ApiOperation({ summary: 'Updates user with given ID' }),
+    ApiOperation({ summary: 'Updates authorized user' }),
     ApiBody({ type: UpdateUserDTO }),
     ApiOkResponse({ type: UserResponse }),
     ApiForbiddenResponse({ description: "User can't be updated" }),

--- a/src/auth/guards/roles.guard.ts
+++ b/src/auth/guards/roles.guard.ts
@@ -1,0 +1,21 @@
+import { ROLES_KEY } from '@common/decorators';
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Role } from '@prisma/client';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<Role[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (!requiredRoles) {
+      return true;
+    }
+    const { user } = context.switchToHttp().getRequest();
+    return requiredRoles.includes(user.role);
+  }
+}

--- a/src/student/student.controller.ts
+++ b/src/student/student.controller.ts
@@ -15,7 +15,7 @@ import { StudentService } from './student.service';
 import { CreateStudentProfileDTO, UpdateStudentProfileDTO } from './dto';
 import { StudentProfileResponse } from './responses';
 import { ApiTags } from '@nestjs/swagger';
-import { Public } from '@common/decorators';
+import { CurrentUser, Public } from '@common/decorators';
 import {
   StudentCreateProfileSwaggerDecorator,
   StudentFindOneSwaggerDecorator,
@@ -28,7 +28,7 @@ import {
 export class StudentController {
   constructor(private readonly studentService: StudentService) {}
 
-  @Get(':userId/profile')
+  @Get(':userId')
   @Public()
   @StudentFindOneSwaggerDecorator()
   async findOne(@Param('userId', ParseUUIDPipe) userId: string) {
@@ -36,23 +36,17 @@ export class StudentController {
     return new StudentProfileResponse(profile);
   }
 
-  @Post(':userId/profile')
+  @Post('self/profile')
   @HttpCode(HttpStatus.CREATED)
   @StudentCreateProfileSwaggerDecorator()
-  async createProfile(
-    @Param('userId', ParseUUIDPipe) userId: string,
-    @Body() createStudentDto: CreateStudentProfileDTO,
-  ) {
+  async createProfile(@CurrentUser('id') userId: string, @Body() createStudentDto: CreateStudentProfileDTO) {
     const profile = await this.studentService.createProfile(userId, createStudentDto);
     return new StudentProfileResponse(profile);
   }
 
-  @Put(':userId/profile')
+  @Put('self/profile')
   @StudentUpdateProfileSwaggerDecorator()
-  async updateProfile(
-    @Param('userId', ParseUUIDPipe) userId: string,
-    @Body() updateStudentDto: UpdateStudentProfileDTO,
-  ) {
+  async updateProfile(@CurrentUser('id') userId: string, @Body() updateStudentDto: UpdateStudentProfileDTO) {
     const profile = await this.studentService.updateProfile(userId, updateStudentDto);
     return new StudentProfileResponse(profile);
   }

--- a/src/student/student.controller.ts
+++ b/src/student/student.controller.ts
@@ -15,12 +15,13 @@ import { StudentService } from './student.service';
 import { CreateStudentProfileDTO, UpdateStudentProfileDTO } from './dto';
 import { StudentProfileResponse } from './responses';
 import { ApiTags } from '@nestjs/swagger';
-import { CurrentUser, Public } from '@common/decorators';
+import { CurrentUser, Public, Roles } from '@common/decorators';
 import {
   StudentCreateProfileSwaggerDecorator,
   StudentFindOneSwaggerDecorator,
   StudentUpdateProfileSwaggerDecorator,
 } from '@common/decorators/swagger/';
+import { Role } from '@prisma/client';
 
 @Controller('students')
 @UseInterceptors(ClassSerializerInterceptor)
@@ -45,6 +46,7 @@ export class StudentController {
   }
 
   @Put('self/profile')
+  @Roles(Role.STUDENT)
   @StudentUpdateProfileSwaggerDecorator()
   async updateProfile(@CurrentUser('id') userId: string, @Body() updateStudentDto: UpdateStudentProfileDTO) {
     const profile = await this.studentService.updateProfile(userId, updateStudentDto);

--- a/src/tutor/tutor.controller.ts
+++ b/src/tutor/tutor.controller.ts
@@ -16,7 +16,7 @@ import { TutorService } from './tutor.service';
 import { CreateAchievementDTO, CreateTutorProfileDTO, UpdateAchievementDTO, UpdateTutorProfileDTO } from './dto';
 import { AchievementResponse, FullTutorProfileResponse, TutorProfileResponse } from './responses';
 import { ApiTags } from '@nestjs/swagger';
-import { CurrentUser, Public } from '@common/decorators';
+import { CurrentUser, Public, Roles } from '@common/decorators';
 import {
   TutorAddAchievementSwaggerDecorator,
   TutorConfirmAchievementSwaggerDecorator,
@@ -26,6 +26,7 @@ import {
   TutorUpdateAchievementSwaggerDecorator,
   TutorUpdateProfileSwaggerDecorator,
 } from '@common/decorators/swagger';
+import { Role } from '@prisma/client';
 
 @Controller('tutors')
 @ApiTags('Tutors')
@@ -42,6 +43,7 @@ export class TutorController {
   }
 
   @Post('self/profile')
+  @Roles(Role.TUTOR)
   @HttpCode(HttpStatus.CREATED)
   @TutorCreateProfileSwaggerDecorator()
   async createProfile(@CurrentUser('id') userId: string, @Body() dto: CreateTutorProfileDTO) {
@@ -50,6 +52,7 @@ export class TutorController {
   }
 
   @Put('self/profile')
+  @Roles(Role.TUTOR)
   @TutorUpdateProfileSwaggerDecorator()
   async updateProfile(@CurrentUser('id') userId: string, @Body() dto: UpdateTutorProfileDTO) {
     const updatedProfile = await this.tutorService.updateProfile(userId, dto);
@@ -57,6 +60,7 @@ export class TutorController {
   }
 
   @Post('self/achievements')
+  @Roles(Role.TUTOR)
   @HttpCode(HttpStatus.CREATED)
   @TutorAddAchievementSwaggerDecorator()
   async addAchievement(@CurrentUser('id') userId: string, @Body() dto: CreateAchievementDTO) {
@@ -65,6 +69,7 @@ export class TutorController {
   }
 
   @Put('self/achievements/:achievementId')
+  @Roles(Role.TUTOR)
   @TutorUpdateAchievementSwaggerDecorator()
   async updateAchievement(
     @Param('achievementId', ParseUUIDPipe) achievementId: string,
@@ -76,6 +81,7 @@ export class TutorController {
   }
 
   @Delete('self/achievements/:achievementId')
+  @Roles(Role.TUTOR)
   @TutorDeleteAchievementSwaggerDecorator()
   async deleteAchievement(
     @CurrentUser('id') userId: string,
@@ -85,6 +91,7 @@ export class TutorController {
   }
 
   @Put(':userId/achievements/:achievementId/confirm')
+  @Roles(Role.ADMIN)
   @TutorConfirmAchievementSwaggerDecorator()
   async confirmAchievement(
     @Param('achievementId', ParseUUIDPipe) achievementId: string,

--- a/src/tutor/tutor.controller.ts
+++ b/src/tutor/tutor.controller.ts
@@ -16,7 +16,7 @@ import { TutorService } from './tutor.service';
 import { CreateAchievementDTO, CreateTutorProfileDTO, UpdateAchievementDTO, UpdateTutorProfileDTO } from './dto';
 import { AchievementResponse, FullTutorProfileResponse, TutorProfileResponse } from './responses';
 import { ApiTags } from '@nestjs/swagger';
-import { Public } from '@common/decorators';
+import { CurrentUser, Public } from '@common/decorators';
 import {
   TutorAddAchievementSwaggerDecorator,
   TutorConfirmAchievementSwaggerDecorator,
@@ -51,8 +51,12 @@ export class TutorController {
 
   @Put(':userId/profile')
   @TutorUpdateProfileSwaggerDecorator()
-  async updateProfile(@Param('userId', ParseUUIDPipe) userId: string, @Body() dto: UpdateTutorProfileDTO) {
-    const updatedProfile = await this.tutorService.updateProfile(userId, dto);
+  async updateProfile(
+    @Param('userId', ParseUUIDPipe) userId: string,
+    @CurrentUser('id') currentUserId: string,
+    @Body() dto: UpdateTutorProfileDTO,
+  ) {
+    const updatedProfile = await this.tutorService.updateProfile(userId, currentUserId, dto);
     return new TutorProfileResponse(updatedProfile);
   }
 

--- a/src/tutor/tutor.controller.ts
+++ b/src/tutor/tutor.controller.ts
@@ -41,49 +41,45 @@ export class TutorController {
     return new FullTutorProfileResponse(profile);
   }
 
-  @Post(':userId/profile')
+  @Post('self/profile')
   @HttpCode(HttpStatus.CREATED)
   @TutorCreateProfileSwaggerDecorator()
-  async createProfile(@Param('userId', ParseUUIDPipe) userId: string, @Body() dto: CreateTutorProfileDTO) {
+  async createProfile(@CurrentUser('id') userId: string, @Body() dto: CreateTutorProfileDTO) {
     const profile = await this.tutorService.createProfile(userId, dto);
     return new TutorProfileResponse(profile);
   }
 
-  @Put(':userId/profile')
+  @Put('self/profile')
   @TutorUpdateProfileSwaggerDecorator()
-  async updateProfile(
-    @Param('userId', ParseUUIDPipe) userId: string,
-    @CurrentUser('id') currentUserId: string,
-    @Body() dto: UpdateTutorProfileDTO,
-  ) {
-    const updatedProfile = await this.tutorService.updateProfile(userId, currentUserId, dto);
+  async updateProfile(@CurrentUser('id') userId: string, @Body() dto: UpdateTutorProfileDTO) {
+    const updatedProfile = await this.tutorService.updateProfile(userId, dto);
     return new TutorProfileResponse(updatedProfile);
   }
 
-  @Post(':userId/achievements')
+  @Post('self/achievements')
   @HttpCode(HttpStatus.CREATED)
   @TutorAddAchievementSwaggerDecorator()
-  async addAchievement(@Param('userId', ParseUUIDPipe) userId: string, @Body() dto: CreateAchievementDTO) {
+  async addAchievement(@CurrentUser('id') userId: string, @Body() dto: CreateAchievementDTO) {
     const achievement = await this.tutorService.addAchievement(userId, dto);
     return new AchievementResponse(achievement);
   }
 
-  @Put(':userId/achievements/:achievementId')
+  @Put('self/achievements/:achievementId')
   @TutorUpdateAchievementSwaggerDecorator()
   async updateAchievement(
     @Param('achievementId', ParseUUIDPipe) achievementId: string,
-    @Param('userId', ParseUUIDPipe) userId: string,
+    @CurrentUser('id') userId: string,
     @Body() dto: UpdateAchievementDTO,
   ) {
     const achievement = await this.tutorService.updateAchievement(userId, achievementId, dto);
     return new AchievementResponse(achievement);
   }
 
-  @Delete(':userId/achievements/:achievementId')
+  @Delete('self/achievements/:achievementId')
   @TutorDeleteAchievementSwaggerDecorator()
   async deleteAchievement(
+    @CurrentUser('id') userId: string,
     @Param('achievementId', ParseUUIDPipe) achievementId: string,
-    @Param('userId', ParseUUIDPipe) userId: string,
   ) {
     return this.tutorService.deleteAchievement(userId, achievementId);
   }

--- a/src/tutor/tutor.service.ts
+++ b/src/tutor/tutor.service.ts
@@ -40,7 +40,7 @@ export class TutorService {
     });
   }
 
-  async updateProfile(userId: string, currentUserId: string, dto: UpdateTutorProfileDTO) {
+  async updateProfile(userId: string, dto: UpdateTutorProfileDTO) {
     // Checking if user exists
     await this.userService.findOne(userId, true);
 
@@ -49,9 +49,6 @@ export class TutorService {
       where: { userId: userId },
     });
     if (!profileExists) throw new BadRequestException('This user does not have a profile');
-
-    // Checking if tutor tries to update his own profile
-    if (userId !== currentUserId) throw new ForbiddenException("Profile can't be updated");
 
     return this.prisma.tutorProfile.update({
       where: {

--- a/src/tutor/tutor.service.ts
+++ b/src/tutor/tutor.service.ts
@@ -40,16 +40,18 @@ export class TutorService {
     });
   }
 
-  async updateProfile(userId: string, dto: UpdateTutorProfileDTO) {
-    const candidate = await this.userService.findOne(userId);
-    if (!candidate) throw new NotFoundException('User not found');
+  async updateProfile(userId: string, currentUserId: string, dto: UpdateTutorProfileDTO) {
+    // Checking if user exists
+    await this.userService.findOne(userId, true);
 
+    // Checking if user has tutor profile
     const profileExists = await this.prisma.tutorProfile.findFirst({
-      where: {
-        userId: userId,
-      },
+      where: { userId: userId },
     });
     if (!profileExists) throw new BadRequestException('This user does not have a profile');
+
+    // Checking if tutor tries to update his own profile
+    if (userId !== currentUserId) throw new ForbiddenException("Profile can't be updated");
 
     return this.prisma.tutorProfile.update({
       where: {

--- a/src/tutor/tutor.service.ts
+++ b/src/tutor/tutor.service.ts
@@ -2,7 +2,7 @@ import { BadRequestException, ForbiddenException, Injectable, NotFoundException 
 import { PrismaService } from '@prisma/prisma.service';
 import { UserService } from '@user/user.service';
 import { CreateAchievementDTO, CreateTutorProfileDTO, UpdateAchievementDTO, UpdateTutorProfileDTO } from './dto';
-import { Role, TutorAchievement, TutorProfile } from '@prisma/client';
+import { TutorAchievement, TutorProfile } from '@prisma/client';
 
 @Injectable()
 export class TutorService {
@@ -23,7 +23,6 @@ export class TutorService {
   async createProfile(userId: string, dto: CreateTutorProfileDTO) {
     const candidate = await this.userService.findOne(userId);
     if (!candidate) throw new NotFoundException('User not found');
-    if (candidate.role !== Role.TUTOR) throw new ForbiddenException();
 
     const profileExists = await this.prisma.tutorProfile.findFirst({
       where: {

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -14,13 +14,14 @@ import { UpdateUserDTO } from '@user/dto';
 import { UserResponse } from '@user/responses';
 import { User } from '@prisma/client';
 import { ApiTags } from '@nestjs/swagger';
-import { Public } from '@common/decorators';
+import { CurrentUser, Public } from '@common/decorators';
 import {
   UserDeleteSwaggerDecorator,
   UserFindAllSwaggerDecorator,
   UserFindOneSwaggerDecorator,
   UserUpdateSwaggerDecorator,
 } from '@common/decorators/swagger';
+import { JwtPayload } from '@auth/interfaces';
 
 @Controller('users')
 @ApiTags('Users')
@@ -53,7 +54,7 @@ export class UserController {
 
   @Delete(':id')
   @UserDeleteSwaggerDecorator()
-  async delete(@Param('id', ParseUUIDPipe) id: string) {
-    return this.userService.delete(id);
+  async delete(@Param('id', ParseUUIDPipe) id: string, @CurrentUser() currentUser: JwtPayload) {
+    return this.userService.delete(id, currentUser);
   }
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -47,8 +47,12 @@ export class UserController {
 
   @Put(':id')
   @UserUpdateSwaggerDecorator()
-  async update(@Param('id', ParseUUIDPipe) id: string, @Body() dto: UpdateUserDTO) {
-    const user = await this.userService.update(id, dto);
+  async update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser('id') currentUserId: string,
+    @Body() dto: UpdateUserDTO,
+  ) {
+    const user = await this.userService.update(id, currentUserId, dto);
     return new UserResponse(user);
   }
 

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -45,14 +45,10 @@ export class UserController {
     return new UserResponse(user);
   }
 
-  @Put(':id')
+  @Put('self')
   @UserUpdateSwaggerDecorator()
-  async update(
-    @Param('id', ParseUUIDPipe) id: string,
-    @CurrentUser('id') currentUserId: string,
-    @Body() dto: UpdateUserDTO,
-  ) {
-    const user = await this.userService.update(id, currentUserId, dto);
+  async update(@CurrentUser('id') id: string, @Body() dto: UpdateUserDTO) {
+    const user = await this.userService.update(id, dto);
     return new UserResponse(user);
   }
 

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,9 +1,10 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '@prisma/prisma.service';
-import { User } from '@prisma/client';
+import { Role, User } from '@prisma/client';
 import { genSalt, hash } from 'bcrypt';
 import { CreateUserDTO, UpdateUserDTO } from '@user/dto';
 import { DeleteResponse } from '@user/responses';
+import { JwtPayload } from '@auth/interfaces';
 
 @Injectable()
 export class UserService {
@@ -53,15 +54,14 @@ export class UserService {
     return this.prisma.user.findMany();
   }
 
-  async delete(id: string): Promise<DeleteResponse> {
-    //   TODO: add check if user tries to delete himself of it is admin
+  async delete(id: string, currentUser: JwtPayload): Promise<DeleteResponse> {
+    if (currentUser.id !== id || currentUser.role !== Role.ADMIN) {
+      throw new ForbiddenException("User can't be deleted");
+    }
+
     return this.prisma.user.delete({
-      where: {
-        id: id,
-      },
-      select: {
-        id: true,
-      },
+      where: { id: id },
+      select: { id: true },
     });
   }
 

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -23,16 +23,15 @@ export class UserService {
     });
   }
 
-  async update(id: string, user: UpdateUserDTO): Promise<User> {
-    await this.findOne(id, true); // Trying to find a user to update
+  async update(id: string, currentUserId: string, user: UpdateUserDTO): Promise<User> {
+    // Trying to find a user to update
+    await this.findOne(id, true);
+    // Checking if user is trying to update himself
+    if (id !== currentUserId) throw new ForbiddenException("User can't be updated");
 
     return this.prisma.user.update({
-      where: {
-        id: id,
-      },
-      data: {
-        ...user,
-      },
+      where: { id: id },
+      data: { ...user },
     });
   }
 

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -23,11 +23,9 @@ export class UserService {
     });
   }
 
-  async update(id: string, currentUserId: string, user: UpdateUserDTO): Promise<User> {
+  async update(id: string, user: UpdateUserDTO): Promise<User> {
     // Trying to find a user to update
     await this.findOne(id, true);
-    // Checking if user is trying to update himself
-    if (id !== currentUserId) throw new ForbiddenException("User can't be updated");
 
     return this.prisma.user.update({
       where: { id: id },


### PR DESCRIPTION
Added roles checking (`Roles` decorator), some endpoints now use `.../self/...` instead of `.../{userId}/...`, so users can edit only thier own data